### PR TITLE
Fail-safe with empty branch name

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -158,7 +158,7 @@ jobs:
               docker manifest inspect "${{ steps.build.outputs.image-repository }}:cache-branch-${branch//[^[:alnum:]]/-}"
           fi
         env:
-          branch: ${{ github.head_ref || (github.ref_type == 'branch' && github.ref_name) }}
+          branch: ${{ github.head_ref || (github.ref_type == 'branch' && github.ref_name || '') }}
       - name: Validate annotations
         run: |
           set -x

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,8 +6,8 @@ on:
       - "action.yaml"
       - ".github/workflows/integration-tests.yaml"
   push:
-    branches: ["main"]
-    tags: ["*"]
+    # branches: ["main"]
+    # tags: ["*"]
     paths:
       - "action.yaml"
       - ".github/workflows/integration-tests.yaml"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,8 +6,8 @@ on:
       - "action.yaml"
       - ".github/workflows/integration-tests.yaml"
   push:
-    # branches: ["main"]
-    # tags: ["*"]
+    branches: ["main"]
+    tags: ["*"]
     paths:
       - "action.yaml"
       - ".github/workflows/integration-tests.yaml"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,6 +6,8 @@ on:
       - "action.yaml"
       - ".github/workflows/integration-tests.yaml"
   push:
+    branches: ["main"]
+    tags: ["*"]
     paths:
       - "action.yaml"
       - ".github/workflows/integration-tests.yaml"
@@ -53,7 +55,8 @@ jobs:
           # address this problem by:
           #
           # 1. Ensuring tests which run in parallel either use separate image repositories
-          #    or different Git commit SHAs.
+          #    or different Git commit SHAs. We also need to take care to ensure that
+          #    builds on `main` are accessible as cached layers for PR images.
           # 2. Utilizing concurrency groups to avoid having multiple instances of this
           #    workflow run in parallel when triggered on the same commit SHA.
           # 3. Deleting the `cache-sha-*` tags to ensure our running workflow produced
@@ -67,19 +70,19 @@ jobs:
           # https://github.com/docker/build-push-action/issues/906#issuecomment-1674567311
           matrix: |
             - title: ${{ github.event_name == 'pull_request' && 'Merge Commit' || '' }}
-              package : temporary/whalesay-pr
+              package : temporary/whalesay
               commit-sha: ${{ github.sha }}
               from-scratch: false
             - title: Head Commit
-              package: temporary/whalesay-${{ github.event_name == 'pull_request' && 'pr' || 'push' }}
+              package: temporary/whalesay
               commit-sha: ${{ github.event.pull_request.head.sha || github.sha }}
               from-scratch: false
             - title: ${{ github.event_name == 'pull_request' && 'Merge Commit From Scratch' || '' }}
-              package: temporary/whalesay-pr-from-scratch
+              package: temporary/whalesay-from-scratch
               commit-sha: ${{ github.sha }}
               from-scratch: true
             - title: Head Commit From Scratch
-              package: temporary/whalesay-${{ github.event_name == 'pull_request' && 'pr' || 'push' }}-from-scratch
+              package: temporary/whalesay-from-scratch
               commit-sha: ${{ github.event.pull_request.head.sha || github.sha }}
               from-scratch: true
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 | `image`            | Reference to the build image including the digest. | `temporary/my-image@sha256:37782d4e1c24d8f12047039a0d3512d1b6059e306a80d5b66a1d9ff60247a8cb` |
 | `image-repository` | The Docker image repository where the image was pushed to. | `temporary/my-image` |
 | `digest`           | The built Docker image digest. | `sha256:37782d4e1c24d8f12047039a0d3512d1b6059e306a80d5b66a1d9ff60247a8cb` |
-| `tags`             | JSON list of tags associated with the built Docker image. | `branch-main`, `sha-152cb14` |
+| `tags`             | JSON list of tags associated with the built Docker image. | `branch-my-branch`, `sha-152cb14`, `pr-123` |
 | `commit-sha`       | The Git commit SHA used to build the image. | `152cb14643b50529b229930d6124e6bbef48668d` |
 
 ## Permissions

--- a/action.yaml
+++ b/action.yaml
@@ -78,8 +78,6 @@ runs:
       run: |
         # Branch
         echo "name=${branch}" | tee -a "$GITHUB_OUTPUT"
-        echo "default=${{ github.event.repository.default_branch }}"
-        [[ "${{ github.event_name == 'push' }}" == "true" ]] && exit 1
       env:
         branch: ${{ github.head_ref || (github.ref_type == 'branch' && github.ref_name || '') }}
     - name: Docker metadata

--- a/action.yaml
+++ b/action.yaml
@@ -79,7 +79,7 @@ runs:
         # Branch
         echo "name=${branch}" | tee -a "$GITHUB_OUTPUT"
       env:
-        branch: ${{ github.head_ref || (github.ref_type == 'branch' && github.ref_name) }}
+        branch: ${{ github.head_ref || (github.ref_type == 'branch' && github.ref_name || '') }}
     - name: Docker metadata
       id: metadata
       uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1

--- a/action.yaml
+++ b/action.yaml
@@ -106,6 +106,7 @@ runs:
           type=sha,prefix=cache-sha-,format=long
           type=raw,prefix=cache-branch-,value=${{ steps.branch.outputs.name }},enable=${{ steps.branch.outputs.name != '' }}
           type=raw,prefix=cache-sha-,value=${{ github.event.pull_request.base.sha }},enable=${{ github.event_name == 'pull_request' }}
+          type=raw,prefix=cache-branch-,value=${{ github.event.repository.default_branch }},enable=${{ github.event_name != 'pull_request' && github.event.repository.default_branch != steps.branch.outputs.name }}
       env:
         # https://github.com/docker/metadata-action/issues/206
         DOCKER_METADATA_PR_HEAD_SHA: ${{ steps.commit.outputs.is-pr-head-sha }}

--- a/action.yaml
+++ b/action.yaml
@@ -51,6 +51,9 @@ runs:
         sha="$(git rev-parse HEAD)"
         echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
 
+        prev_sha="$(git rev-parse HEAD^)"
+        echo "prev-sha=$prev_sha" | tee -a "$GITHUB_OUTPUT"
+
         # When building the Docker image we'll generate tags and annotations which include
         # the commit SHA. Due to limitations with `docker/metadata-action` it's rather
         # difficult to get this working for an arbitrary commit. For now we'll limit this

--- a/action.yaml
+++ b/action.yaml
@@ -78,6 +78,8 @@ runs:
       run: |
         # Branch
         echo "name=${branch}" | tee -a "$GITHUB_OUTPUT"
+        echo "default=${{ github.event.repository.default_branch }}"
+        [[ "${{ github.event_name == 'push' }}" == "true" ]] && exit 1
       env:
         branch: ${{ github.head_ref || (github.ref_type == 'branch' && github.ref_name || '') }}
     - name: Docker metadata

--- a/action.yaml
+++ b/action.yaml
@@ -51,9 +51,6 @@ runs:
         sha="$(git rev-parse HEAD)"
         echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
 
-        prev_sha="$(git rev-parse HEAD^)"
-        echo "prev-sha=$prev_sha" | tee -a "$GITHUB_OUTPUT"
-
         # When building the Docker image we'll generate tags and annotations which include
         # the commit SHA. Due to limitations with `docker/metadata-action` it's rather
         # difficult to get this working for an arbitrary commit. For now we'll limit this


### PR DESCRIPTION
Branch name on `main` is resolving to `false`: https://github.com/beacon-biosignals/docker-build/actions/runs/12876123486/job/35898954790#step:5:262. This change should at least result in not writing out `cache-branch-false`. Not sure why we aren't picking up `main` yet.