### PR TITLE
Always build images on `main`

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -7,12 +7,9 @@ on:
       - "test/**"
       - ".github/workflows/integration-tests.yaml"
   push:
+    # Always build images on `main` so future PRs have a cached image to work off of
     branches: ["main"]
     tags: ["*"]
-    paths:
-      - "action.yaml"
-      - "test/**"
-      - ".github/workflows/integration-tests.yaml"
 
 concurrency:
   group: integration-tests-${{ github.event_name == 'pull_request' && 'pr' || 'push' }}-${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Noticed with dependabot failures that this was a problem.