### PR TITLE
Support persistent Docker cache mounts

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -122,6 +122,9 @@ jobs:
           build-args: |
             DEBIAN_VERSION=12.9
           from-scratch: ${{ matrix.test.from-scratch || 'false' }}
+          cache-mount-ids: |
+            /var/cache/apt
+            /var/lib/apt
       - name: Validate image works
         run: |
           docker pull "${{ steps.build.outputs.image }}"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ jobs:
             github-token=${{ secrets.token || github.token }}
           # Build images from scratch on "main". Ensures that caching doesn't result in using insecure system packages.
           from-scratch: ${{ github.ref == 'refs/heads/main' }}
+          cache-mount-ids: |
+            /var/cache/apt
+            /var/lib/apt
 ```
 
 ## Inputs
@@ -48,6 +51,7 @@ jobs:
 | `build-args`         | List of [build-time variables](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg). | No | <pre><code>HTTP_PROXY=http://10.20.30.2:1234 &#10;FTP_PROXY=http://40.50.60.5:4567</code></pre> |
 | `build-secrets`      | List of [secrets](https://docs.docker.com/engine/reference/commandline/buildx_build/#secret) to expose to the build. | No | <pre><code>GIT_AUTH_TOKEN=mytoken</code></pre> |
 | `from-scratch`       | Do not use cache when building the image. Defaults to `false`. | No | `false` |
+| `cache-mount-ids`    | List of build [cache mount IDs or targets](https://docs.docker.com/reference/dockerfile/#run---mounttypecache) to preserve across builds. | No | <pre><code>/var/cache/apt&#10;/var/lib/apt</code></pre> |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
 | `context`            | The Docker build context directory. Defaults to `.`. | No | `./my-image` |
 | `build-args`         | List of [build-time variables](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg). | No | <pre><code>HTTP_PROXY=http://10.20.30.2:1234 &#10;FTP_PROXY=http://40.50.60.5:4567</code></pre> |
 | `build-secrets`      | List of [secrets](https://docs.docker.com/engine/reference/commandline/buildx_build/#secret) to expose to the build. | No | <pre><code>GIT_AUTH_TOKEN=mytoken</code></pre> |
-| `from-scratch`       | Do not use cache when building the image. Defaults to `false`. | No | `false` |
+| `from-scratch`       | Do not read from the cache when building the image. Writes to caches will still occur. Defaults to `false`. | No | `false` |
 | `cache-mount-ids`    | List of build [cache mount IDs or targets](https://docs.docker.com/reference/dockerfile/#run---mounttypecache) to preserve across builds. | No | <pre><code>/var/cache/apt&#10;/var/lib/apt</code></pre> |
 
 ## Outputs

--- a/action.yaml
+++ b/action.yaml
@@ -156,7 +156,7 @@ runs:
         restore-keys: |
           julia-depot-cache
     - name: Restore Docker cache mounts
-      uses: reproducible-containers/buildkit-cache-dance@5b6db76d1da5c8b307d5d2e0706d266521b710de # v3.1.2
+      uses: reproducible-containers/buildkit-cache-dance@61bd187f75f25d38e056fdd48506fac777c6ebec
       with:
         cache-map: |
           {

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,8 @@ inputs:
   from-scratch:
     description: Do not read from the cache when building the image.
     default: "false"
+  cache-mount-ids:
+    default: ""
 outputs:
   image:
     description: Reference to the build image including the digest.
@@ -151,18 +153,18 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          julia-depot-cache
-        key: julia-depot-cache-${{ hashFiles(format('{0}/**', inputs.context)) }}
+          ${{ github.action_path }}/cache-mount
+        key: docker-build-cache-mount-${{ hashFiles(format('{0}/**', inputs.context)) }}
         restore-keys: |
-          julia-depot-cache
+          docker-build-cache-mount
     - name: Restore Docker cache mounts
       uses: reproducible-containers/buildkit-cache-dance@61bd187f75f25d38e056fdd48506fac777c6ebec
       with:
         cache-map: |
           {
-            "julia-depot-cache": {
-              "target": "/mnt/julia-depot",
-              "id": "julia-depot"
+            "${{ github.action_path }}/cache-mount/julia-depot": {
+              "id": "julia-depot",
+              "target": "/tmp/julia-depot"
             }
           }
         builder: ${{ steps.builder.outputs.name }}

--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,9 @@ inputs:
   from-scratch:
     description: Do not read from the cache when building the image.
     default: "false"
+  # https://docs.docker.com/reference/dockerfile/#run---mounttypecache
   cache-mount-ids:
+    description: List of build cache mount IDs or targets to preserve across builds.
     default: ""
 outputs:
   image:
@@ -155,6 +157,9 @@ runs:
       run: |
         # Process cache mount IDs
         ids_json="$(jq -R 'select(. != "")' <<<"${cache_mount_ids}" | jq -sc .)"
+
+        # We fully support user provided IDs which are absolute paths.
+        bind_root="$(readlink -f "${bind_root:?}")"
         cache_map_json="$(jq --arg bind_root "${bind_root:?}" 'map(. as $id | {"key": ($bind_root + "/" + $id), "value": {"id": $id, "target": ("/tmp/" + $id)}}) | from_entries' <<<"${ids_json}")"
 
         # Specify our multiline output using GH action flavored heredocs

--- a/action.yaml
+++ b/action.yaml
@@ -157,6 +157,7 @@ runs:
         key: docker-build-cache-mount-${{ hashFiles(format('{0}/**', inputs.context)) }}
         restore-keys: |
           docker-build-cache-mount
+    # https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts
     - name: Restore Docker cache mounts
       uses: reproducible-containers/buildkit-cache-dance@61bd187f75f25d38e056fdd48506fac777c6ebec
       with:
@@ -173,7 +174,7 @@ runs:
       uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
       with:
         context: ${{ inputs.context }}
-        builder: ${{ steps.setup-buildx.outputs.name }}
+        builder: ${{ steps.builder.outputs.name }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.build-secrets }}
         cache-from: ${{ steps.cache.outputs.from-tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,6 @@ inputs:
   from-scratch:
     description: Do not read from the cache when building the image.
     default: "false"
-  # https://docs.docker.com/reference/dockerfile/#run---mounttypecache
   cache-mount-ids:
     description: List of build cache mount IDs or targets to preserve across builds.
     default: ""

--- a/action.yaml
+++ b/action.yaml
@@ -20,9 +20,6 @@ inputs:
   from-scratch:
     description: Do not read from the cache when building the image.
     default: "false"
-  builder:
-    description: The name of the buildx builder to use.
-    default: ""
 outputs:
   image:
     description: Reference to the build image including the digest.
@@ -44,7 +41,6 @@ runs:
   steps:
     - name: Set up Docker Buildx
       id: builder
-      if: ${{ inputs.builder == '' }}
       uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       with:
         driver: docker-container
@@ -151,12 +147,31 @@ runs:
       env:
         from_tags: ${{ steps.cache-from.outputs.tags }}
         to_tags: ${{ steps.cache-to.outputs.tags }}
+    - name: Retrieve Docker cache mount bundle
+      uses: actions/cache@v4
+      with:
+        path: |
+          julia-depot-cache
+        key: julia-depot-cache-${{ hashFiles(format('{0}/Manifest.toml', fromJSON(steps.service.outputs.json).service-harness.path)) }}
+        restore-keys: |
+          julia-depot-cache
+    - name: Restore Docker cache mounts
+      uses: reproducible-containers/buildkit-cache-dance@5b6db76d1da5c8b307d5d2e0706d266521b710de # v3.1.2
+      with:
+        cache-map: |
+          {
+            "julia-depot-cache": {
+              "target": "/mnt/julia-depot",
+              "id": "julia-depot"
+            }
+          }
+        builder: ${{ steps.builder.outputs.name }}
     - name: Build and Push
       id: build-push
       uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
       with:
         context: ${{ inputs.context }}
-        builder: ${{ inputs.builder || steps.setup-buildx.outputs.name }}
+        builder: ${{ steps.setup-buildx.outputs.name }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.build-secrets }}
         cache-from: ${{ steps.cache.outputs.from-tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -149,6 +149,23 @@ runs:
       env:
         from_tags: ${{ steps.cache-from.outputs.tags }}
         to_tags: ${{ steps.cache-to.outputs.tags }}
+    - name: Process cache mount IDs
+      id: cache-mount
+      run: |
+        # Process cache mount IDs
+        cache_mount_ids="$(yq '. // []' -o json <<<"${cache_mount_ids}" | jq -r 'if type == "array" then . else error("\"cache-mount-ids\" root element must be a list") end')"
+        cache_map="$(jq --arg bind_root "${bind_root:?}" 'map(. as $id | {"key": ($bind_root + "/" + $id), "value": {"id": $id, "target": ("/tmp/" + $id)}}) | from_entries' <<<"${cache_map_ids}")"
+
+        # Specify our multiline output using GH action flavored heredocs
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        {
+            echo "cache-map<<EOF"
+            jq <<<"${cache_map}"
+            echo "EOF"
+        } | tee -a "$GITHUB_OUTPUT"
+      env:
+        cache_mount_ids: ${{ inputs.cache-mount-ids }}
+        bind_root: ${{ github.action_path }}/cache-mount
     - name: Retrieve Docker cache mount bundle
       uses: actions/cache@v4
       with:
@@ -161,13 +178,7 @@ runs:
     - name: Restore Docker cache mounts
       uses: reproducible-containers/buildkit-cache-dance@61bd187f75f25d38e056fdd48506fac777c6ebec
       with:
-        cache-map: |
-          {
-            "${{ github.action_path }}/cache-mount/julia-depot": {
-              "id": "julia-depot",
-              "target": "/tmp/julia-depot"
-            }
-          }
+        cache-map: ${{ steps.cache-mount.outputs.cache-map }}
         builder: ${{ steps.builder.outputs.name }}
     - name: Build and Push
       id: build-push

--- a/action.yaml
+++ b/action.yaml
@@ -152,7 +152,7 @@ runs:
       with:
         path: |
           julia-depot-cache
-        key: julia-depot-cache-${{ hashFiles(format('{0}/Manifest.toml', fromJSON(steps.service.outputs.json).service-harness.path)) }}
+        key: julia-depot-cache-${{ hashFiles(format('{0}/**', inputs.context)) }}
         restore-keys: |
           julia-depot-cache
     - name: Restore Docker cache mounts

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,9 @@ inputs:
     description: List of secrets to expose to the build.
     required: false
   from-scratch:
-    description: Do not read from the cache when building the image.
+    description: >-
+      Do not read from the cache when building the image. Writes to caches will still
+      occur.
     default: "false"
   cache-mount-ids:
     description: List of build cache mount IDs or targets to preserve across builds.

--- a/action.yaml
+++ b/action.yaml
@@ -36,10 +36,14 @@ outputs:
   commit-sha:
     description: The Git commit SHA used to build the image.
     value: ${{ steps.commit.outputs.sha }}
+  builder:
+    description The name of the buildx builder used.
+    value ${{ steps.setup-buildx.outputs.name }}
 runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
+      id: builder
       uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       with:
         driver: docker-container

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,9 @@ inputs:
   from-scratch:
     description: Do not read from the cache when building the image.
     default: "false"
+  builder:
+    description: The name of the buildx builder to use.
+    default: ""
 outputs:
   image:
     description: Reference to the build image including the digest.
@@ -36,14 +39,12 @@ outputs:
   commit-sha:
     description: The Git commit SHA used to build the image.
     value: ${{ steps.commit.outputs.sha }}
-  builder:
-    description The name of the buildx builder used.
-    value ${{ steps.setup-buildx.outputs.name }}
 runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
       id: builder
+      if: ${{ inputs.builder == '' }}
       uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       with:
         driver: docker-container
@@ -155,6 +156,7 @@ runs:
       uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
       with:
         context: ${{ inputs.context }}
+        builder: ${{ inputs.builder || steps.setup-buildx.outputs.name }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.build-secrets }}
         cache-from: ${{ steps.cache.outputs.from-tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -151,6 +151,7 @@ runs:
         to_tags: ${{ steps.cache-to.outputs.tags }}
     - name: Process cache mount IDs
       id: cache-mount
+      shell: bash
       run: |
         # Process cache mount IDs
         ids_json="$(jq -R 'select(. != "")' <<<"${cache_mount_ids}" | jq -sc .)"

--- a/action.yaml
+++ b/action.yaml
@@ -153,14 +153,14 @@ runs:
       id: cache-mount
       run: |
         # Process cache mount IDs
-        cache_mount_ids="$(yq '. // []' -o json <<<"${cache_mount_ids}" | jq -r 'if type == "array" then . else error("\"cache-mount-ids\" root element must be a list") end')"
-        cache_map="$(jq --arg bind_root "${bind_root:?}" 'map(. as $id | {"key": ($bind_root + "/" + $id), "value": {"id": $id, "target": ("/tmp/" + $id)}}) | from_entries' <<<"${cache_map_ids}")"
+        ids_json="$(jq -R 'select(. != "")' <<<"${cache_mount_ids}" | jq -sc .)"
+        cache_map_json="$(jq --arg bind_root "${bind_root:?}" 'map(. as $id | {"key": ($bind_root + "/" + $id), "value": {"id": $id, "target": ("/tmp/" + $id)}}) | from_entries' <<<"${ids_json}")"
 
         # Specify our multiline output using GH action flavored heredocs
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
             echo "cache-map<<EOF"
-            jq <<<"${cache_map}"
+            jq <<<"${cache_map_json}"
             echo "EOF"
         } | tee -a "$GITHUB_OUTPUT"
       env:


### PR DESCRIPTION
Allows `RUN --mount=cache` entries to persist between CI workflows to reduce image build times. Currently we use the GitHub Action cache as the backend for this but I have plans to use the temporary OCI compatible image registry as the backend to store this data (probably using [ORAS](https://oras.land/docs/)).

I haven't integrated any tests into this and I think I'll make an issue to tackle that separately.