### PR TITLE
Generate `cache-map` from Dockerfile

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -122,9 +122,6 @@ jobs:
           build-args: |
             DEBIAN_VERSION=12.9
           from-scratch: ${{ matrix.test.from-scratch || 'false' }}
-          cache-mount-ids: |
-            /var/cache/apt
-            /var/lib/apt
       - name: Validate image works
         run: |
           docker pull "${{ steps.build.outputs.image }}"

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ jobs:
             github-token=${{ secrets.token || github.token }}
           # Build images from scratch on "main". Ensures that caching doesn't result in using insecure system packages.
           from-scratch: ${{ github.ref == 'refs/heads/main' }}
-          cache-mount-ids: |
-            /var/cache/apt
-            /var/lib/apt
 ```
 
 ## Inputs
@@ -52,7 +49,7 @@ jobs:
 | `build-args`         | List of [build-time variables](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg). | No | <pre><code>HTTP_PROXY=http://10.20.30.2:1234 &#10;FTP_PROXY=http://40.50.60.5:4567</code></pre> |
 | `build-secrets`      | List of [secrets](https://docs.docker.com/engine/reference/commandline/buildx_build/#secret) to expose to the build. | No | <pre><code>GIT_AUTH_TOKEN=mytoken</code></pre> |
 | `from-scratch`       | Do not read from the cache when building the image. Writes to caches will still occur. Defaults to `false`. | No | `false` |
-| `cache-mount-ids`    | List of build [cache mount IDs or targets](https://docs.docker.com/reference/dockerfile/#run---mounttypecache) to preserve across builds. | No | <pre><code>/var/cache/apt&#10;/var/lib/apt</code></pre> |
+| `cache-mount-ids`    | List of build [cache mount IDs or targets](https://docs.docker.com/reference/dockerfile/#run---mounttypecache) to preserve across builds. By default the IDs are determined from the Dockerfile as specified in `dockerfile`. | No | <pre><code>/var/cache/apt&#10;/var/lib/apt</code></pre> |
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -157,6 +157,13 @@ runs:
       env:
         from_tags: ${{ steps.cache-from.outputs.tags }}
         to_tags: ${{ steps.cache-to.outputs.tags }}
+    # Clean up the bind root path which otherwise may look like: /home/runner/work/docker-build/docker-build/.//cache-mount
+    - name: Bind root
+      id: bind-root
+      shell: bash
+      run: echo "path=$(readlink -f "${bind_root:?}")" | tee -a "$GITHUB_OUTPUT"
+      env:
+        bind_root: ${{ github.action_path }}/cache-mount
     - name: Process cache mount IDs
       id: cache-mount
       if: ${{ inputs.cache-mount-ids != '' }}
@@ -166,7 +173,6 @@ runs:
         ids_json="$(jq -R 'select(. != "")' <<<"${cache_mount_ids}" | jq -sc .)"
 
         # We fully support user provided IDs which are absolute paths.
-        bind_root="$(readlink -f "${bind_root:?}")"
         cache_map_json="$(jq --arg bind_root "${bind_root:?}" 'map(. as $id | {"key": ($bind_root + "/" + $id), "value": {"id": $id, "target": ("/tmp/" + $id)}}) | from_entries' <<<"${ids_json}")"
 
         # Specify our multiline output using GH action flavored heredocs
@@ -178,12 +184,11 @@ runs:
         } | tee -a "$GITHUB_OUTPUT"
       env:
         cache_mount_ids: ${{ inputs.cache-mount-ids }}
-        bind_root: ${{ github.action_path }}/cache-mount
+        bind_root: ${{ steps.bind-root.outputs.path }}
     - name: Retrieve Docker cache mount bundle
       uses: actions/cache@v4
       with:
-        path: |
-          ${{ github.action_path }}/cache-mount
+        path: ${{ steps.bind-root.outputs.path }}
         key: docker-build-cache-mount-${{ hashFiles(format('{0}/**', inputs.context)) }}
         restore-keys: |
           docker-build-cache-mount
@@ -194,7 +199,7 @@ runs:
       with:
         cache-map: ${{ steps.cache-mount.outputs.cache-map }}
         dockerfile: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
-        cache-dir: ${{ github.action_path }}/cache-mount
+        cache-dir: ${{ steps.bind-root.outputs.path }}
         builder: ${{ steps.builder.outputs.name }}
     - name: Build and Push
       id: build-push

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,9 @@ inputs:
       occur.
     default: "false"
   cache-mount-ids:
-    description: List of build cache mount IDs or targets to preserve across builds.
+    description: >-
+      List of build cache mount IDs or targets to preserve across builds. By default the
+      IDs are determined from the Dockerfile as specified in `dockerfile`.
     default: ""
 outputs:
   image:

--- a/action.yaml
+++ b/action.yaml
@@ -194,8 +194,7 @@ runs:
           docker-build-cache-mount
     # https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts
     - name: Restore Docker cache mounts
-      # uses: reproducible-containers/buildkit-cache-dance@cv/cache-dir
-      uses: omus/buildkit-cache-dance@2b4f808c9429730cd144d5eb130dfdc499cfc3a8
+      uses: reproducible-containers/buildkit-cache-dance@5b81f4d29dc8397a7d341dba3aeecc7ec54d6361 # v3.3.0
       with:
         cache-map: ${{ steps.cache-mount.outputs.cache-map }}
         dockerfile: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}

--- a/action.yaml
+++ b/action.yaml
@@ -159,6 +159,7 @@ runs:
         to_tags: ${{ steps.cache-to.outputs.tags }}
     - name: Process cache mount IDs
       id: cache-mount
+      if: ${{ inputs.cache-mount-ids != '' }}
       shell: bash
       run: |
         # Process cache mount IDs
@@ -188,9 +189,10 @@ runs:
           docker-build-cache-mount
     # https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts
     - name: Restore Docker cache mounts
-      uses: reproducible-containers/buildkit-cache-dance@61bd187f75f25d38e056fdd48506fac777c6ebec
+      uses: reproducible-containers/buildkit-cache-dance@653a570f730e3b9460adc576db523788ba59a0d7 # v3.2.0
       with:
         cache-map: ${{ steps.cache-mount.outputs.cache-map }}
+        dockerfile: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
         builder: ${{ steps.builder.outputs.name }}
     - name: Build and Push
       id: build-push

--- a/action.yaml
+++ b/action.yaml
@@ -189,10 +189,12 @@ runs:
           docker-build-cache-mount
     # https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts
     - name: Restore Docker cache mounts
-      uses: reproducible-containers/buildkit-cache-dance@653a570f730e3b9460adc576db523788ba59a0d7 # v3.2.0
+      # uses: reproducible-containers/buildkit-cache-dance@cv/cache-dir
+      uses: omus/buildkit-cache-dance@cv/cache-dir
       with:
         cache-map: ${{ steps.cache-mount.outputs.cache-map }}
         dockerfile: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
+        cache-dir: ${{ github.action_path }}/cache-mount
         builder: ${{ steps.builder.outputs.name }}
     - name: Build and Push
       id: build-push

--- a/action.yaml
+++ b/action.yaml
@@ -195,7 +195,7 @@ runs:
     # https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts
     - name: Restore Docker cache mounts
       # uses: reproducible-containers/buildkit-cache-dance@cv/cache-dir
-      uses: omus/buildkit-cache-dance@cv/cache-dir
+      uses: omus/buildkit-cache-dance@2b4f808c9429730cd144d5eb130dfdc499cfc3a8
       with:
         cache-map: ${{ steps.cache-mount.outputs.cache-map }}
         dockerfile: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}


### PR DESCRIPTION
Utilize the automatic cache map generation added to `buildkit-cache-dance`.

Depends on:
- https://github.com/reproducible-containers/buildkit-cache-dance/pull/52

After we get this PR in we should drop `cache-mount-ids` and make a breaking release.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210389681928859