### PR TITLE
Drop `cache-mount-ids`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ When using this action we recommend utilizing a separate image repositories for 
 
 Note that although [Docker does support using GitHub Actions cache](https://docs.docker.com/build/cache/backends/gha/) as a layer cache backend the GHA cache limit for a repository is 10 GB which is quite limiting for larger Docker images.
 
+If your Dockerfile makes [use of cache mounts](https://docs.docker.com/build/cache/optimize/#use-cache-mounts) (e.g. `--mount=type=cache`) then that cache information will be stored/restored from the GitHub Actions cache. This allows for faster Docker builds when layers are invalidated.
+
 ## Example
 
 ```yaml
@@ -49,7 +51,6 @@ jobs:
 | `build-args`         | List of [build-time variables](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg). | No | <pre><code>HTTP_PROXY=http://10.20.30.2:1234 &#10;FTP_PROXY=http://40.50.60.5:4567</code></pre> |
 | `build-secrets`      | List of [secrets](https://docs.docker.com/engine/reference/commandline/buildx_build/#secret) to expose to the build. | No | <pre><code>GIT_AUTH_TOKEN=mytoken</code></pre> |
 | `from-scratch`       | Do not read from the cache when building the image. Writes to caches will still occur. Defaults to `false`. | No | `false` |
-| `cache-mount-ids`    | List of build [cache mount IDs or targets](https://docs.docker.com/reference/dockerfile/#run---mounttypecache) to preserve across builds. By default the IDs are determined from the Dockerfile as specified in `dockerfile`. | No | <pre><code>/var/cache/apt&#10;/var/lib/apt</code></pre> |
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -27,11 +27,6 @@ inputs:
       Do not read from the cache when building the image. Writes to caches will still
       occur.
     default: "false"
-  cache-mount-ids:
-    description: >-
-      List of build cache mount IDs or targets to preserve across builds. By default the
-      IDs are determined from the Dockerfile as specified in `dockerfile`.
-    default: ""
 outputs:
   image:
     description: Reference to the build image including the digest.
@@ -166,27 +161,6 @@ runs:
       run: echo "path=$(readlink -f "${bind_root:?}")" | tee -a "$GITHUB_OUTPUT"
       env:
         bind_root: ${{ github.action_path }}/cache-mount
-    - name: Process cache mount IDs
-      id: cache-mount
-      if: ${{ inputs.cache-mount-ids != '' }}
-      shell: bash
-      run: |
-        # Process cache mount IDs
-        ids_json="$(jq -R 'select(. != "")' <<<"${cache_mount_ids}" | jq -sc .)"
-
-        # We fully support user provided IDs which are absolute paths.
-        cache_map_json="$(jq --arg bind_root "${bind_root:?}" 'map(. as $id | {"key": ($bind_root + "/" + $id), "value": {"id": $id, "target": ("/tmp/" + $id)}}) | from_entries' <<<"${ids_json}")"
-
-        # Specify our multiline output using GH action flavored heredocs
-        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-        {
-            echo "cache-map<<EOF"
-            jq <<<"${cache_map_json}"
-            echo "EOF"
-        } | tee -a "$GITHUB_OUTPUT"
-      env:
-        cache_mount_ids: ${{ inputs.cache-mount-ids }}
-        bind_root: ${{ steps.bind-root.outputs.path }}
     - name: Retrieve Docker cache mount bundle
       uses: actions/cache@v4
       with:
@@ -198,7 +172,6 @@ runs:
     - name: Restore Docker cache mounts
       uses: reproducible-containers/buildkit-cache-dance@5b81f4d29dc8397a7d341dba3aeecc7ec54d6361 # v3.3.0
       with:
-        cache-map: ${{ steps.cache-mount.outputs.cache-map }}
         dockerfile: ${{ inputs.dockerfile || format('{0}/Dockerfile', inputs.context) }}
         cache-dir: ${{ steps.bind-root.outputs.path }}
         builder: ${{ steps.builder.outputs.name }}


### PR DESCRIPTION
Breaking change. Removes support for manually specifying the `cache-mount-ids`.